### PR TITLE
fix(플레이): previous_sheet_infos null optional

### DIFF
--- a/src/pages/StoryPlay/index.tsx
+++ b/src/pages/StoryPlay/index.tsx
@@ -174,7 +174,7 @@ function StoryPlayPage() {
         )}
       </div>
       <div className="flex justify-center gap-3">
-        {(sheet?.previous_sheet_infos.length || 0) > 0 && (
+        {(sheet?.previous_sheet_infos?.length || 0) > 0 && (
           <button className={OUTLINE_BUTTON_STYLE} onClick={handlePrevSheet}>
             이전
           </button>


### PR DESCRIPTION
- 문제: 플레이페이지 첫 진입시 렌더링되지 않음
- 해결: previous_sheet_infos가 null일 수 있어 optional 처리함